### PR TITLE
Use Ubuntu 16.04/18.04 way to get default gateway IP

### DIFF
--- a/deb/etc/ces/functions.sh
+++ b/deb/etc/ces/functions.sh
@@ -127,11 +127,7 @@ function get_ip(){
     fi
   else
     # use ip address of default gateway
-    if [[ $(get_ubuntu_version) == "16.04" ]]; then
-      ip -4 addr show "$(ip -4 route list 0/0 | awk '{print $NF}')" | grep inet | awk '{print $2}' | awk -F'/' '{print $1}'
-    else
-      ip -4 addr show "$(ip -4 route list 0/0 | awk '{print $5}')" | grep inet | awk '{print $2}' | awk -F'/' '{print $1}'
-    fi
+    ip -4 addr show "$(ip -4 route list 0/0 | awk '{print $5}')" | grep inet | awk '{print $2}' | awk -F'/' '{print $1}'
   fi
 }
 


### PR DESCRIPTION
Use a function which is working in Ubuntu 16.04 and Ubuntu 18.04 to get the IP address of the default gateway.

Resolves #3