### PR TITLE
Bugfix/11 upgradability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+* Conflict resolution in upgrades from ces-commons < 0.1.4
+* Upgrade problem with old systemd version (e.g. used in Ubuntu 16.04) (#11)
+
 ## [v0.2.0]()(https://github.com/cloudogu/ces-commons/releases/tag/v0.2.0) - 2019-12-11
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include build/make/variables.mk
 
 # You may want to overwrite existing variables for pre/post target actions to fit into your project.
 
-PREPARE_PACKAGE=$(DEBIAN_CONTENT_DIR)/control/postinst $(DEBIAN_CONTENT_DIR)/control/prerm $(DEBIAN_CONTENT_DIR)/control/prerm
+PREPARE_PACKAGE=$(DEBIAN_CONTENT_DIR)/control/preinst $(DEBIAN_CONTENT_DIR)/control/postinst $(DEBIAN_CONTENT_DIR)/control/prerm $(DEBIAN_CONTENT_DIR)/control/prerm
 
 include build/make/info.mk
 #include build/make/build.mk
@@ -26,6 +26,9 @@ include build/make/digital-signature.mk
 #include build/make/bower.mk
 
 default: debian signature
+
+$(DEBIAN_CONTENT_DIR)/control/preinst: $(DEBIAN_CONTENT_DIR)/control
+	@install -p -m 0755 $(WORKDIR)/deb/DEBIAN/preinst $@
 
 $(DEBIAN_CONTENT_DIR)/control/postinst: $(DEBIAN_CONTENT_DIR)/control
 	@install -p -m 0755 $(WORKDIR)/deb/DEBIAN/postinst $@

--- a/deb/DEBIAN/postinst
+++ b/deb/DEBIAN/postinst
@@ -5,5 +5,6 @@
 
 sysctl --system
 systemctl daemon-reload
+systemctl disable ipchangecheck.service
 systemctl enable ipchangecheck.service
 /etc/cron.daily/motdUpdate > /dev/null 2>&1

--- a/deb/DEBIAN/preinst
+++ b/deb/DEBIAN/preinst
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
 # this is for upgrades of ces-commons < 0.1.4
-if [ ! -f "/var/lib/dpkg/info/ces-commons.conffiles" ]; then
+if [ ! -f "/var/lib/dpkg/info/ces-commons.conffiles" ] && [ -f /etc/ces/functions.sh ]; then
     rm /etc/ces/functions.sh
 fi

--- a/deb/DEBIAN/preinst
+++ b/deb/DEBIAN/preinst
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+# this is for ces-commons versions < 0.1.4
+if [ ! -f "/var/lib/dpkg/info/ces-commons.conffiles" ]; then
+    rm /etc/ces/functions.sh
+fi

--- a/deb/DEBIAN/preinst
+++ b/deb/DEBIAN/preinst
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-# this is for ces-commons versions < 0.1.4
+# this is for upgrades of ces-commons < 0.1.4
 if [ ! -f "/var/lib/dpkg/info/ces-commons.conffiles" ]; then
     rm /etc/ces/functions.sh
 fi


### PR DESCRIPTION
### Fixed
* Conflict resolution in upgrades from ces-commons < 0.1.4
* Upgrade problem with old systemd version (e.g. used in Ubuntu 16.04) (#11)