### PR TITLE
Use new enp0s8 and enp0s3 network interface names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Changed
+- Use new enp0s8 and enp0s3 network interface names to determine IP address; #26
 
 ## [v0.8.0](https://github.com/cloudogu/ces-commons/releases/tag/v0.8.0) - 2021-04-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## Changed
+### Changed
 - Use new enp0s8 and enp0s3 network interface names to determine IP address; #26
 
 ## [v0.8.0](https://github.com/cloudogu/ces-commons/releases/tag/v0.8.0) - 2021-04-22

--- a/deb/etc/ces/functions.sh
+++ b/deb/etc/ces/functions.sh
@@ -118,12 +118,12 @@ function get_ip(){
   TYPE=$(get_type)
   if [ "${TYPE}" = "vagrant" ]; then
     EXISTING_INTERFACES=$(ip link show)
-    ETH1="eth1"
-    if [ -z "${EXISTING_INTERFACES##*$ETH1*}" ]; then
-      # eth1 exists, use its ip address
-      get_and_print_ip_of eth1
+    ENP0S8="enp0s8"
+    if [ -z "${EXISTING_INTERFACES##*$ENP0S8*}" ]; then
+      # enp0s8 exists, use its ip address
+      get_and_print_ip_of ${ENP0S8}
     else
-      get_and_print_ip_of eth0
+      get_and_print_ip_of enp0s3
     fi
   elif [ "${TYPE}" = "azure" ]; then
     get_and_print_external_ip_via_AWS


### PR DESCRIPTION
### Changed
- Use new enp0s8 and enp0s3 network interface names to determine IP address in vagrant machines

Resolves #26 